### PR TITLE
Makes mapping from angle to pwm and back consistent

### DIFF
--- a/sedani/sedani_chassis/sedani_chassis.ino
+++ b/sedani/sedani_chassis/sedani_chassis.ino
@@ -228,8 +228,7 @@ float linearMap(float x, float in_min, float in_max, float out_min, float out_ma
 }
 
 float radiansFromServoPwm(unsigned long pwm) {
-  //@note the maximum steering pwm is actually going to a negative radian value (to the left)
-  //and the min steering pwm is actually going to the right in the positive direction
+  //@note This is split into two to ensure that a center pwm actually maps to our 0 exactly
   if(pwm < centerSteeringPwm) {
     return linearMap((float)pwm, minSteeringPwm, centerSteeringPwm, minSteeringAngle, 0.0);
   } else {
@@ -238,8 +237,7 @@ float radiansFromServoPwm(unsigned long pwm) {
 }
 
 unsigned long servoPwmFromRadians(float radians) {
-  //@note the maximum steering pwm is actually going to a negative radian value (to the left)
-  //and the min steering pwm is actually going to the right in the positive direction
+  //@note This is split into two to ensure that 0 radians actually maps to our center pwm exactly
   if (radians < 0.0) {
     return linearMap(radians, minSteeringAngle, 0.0, minSteeringPwm, centerSteeringPwm);
   } else {


### PR DESCRIPTION
Fixes #11 . The old angle to pwm and back conversion was off by a small amount, so given an angle, you could get a pwm but that same pwm would not give the original angle. This implements a floating point math version of Arduino's map function, which maps back and forth properly.

Waiting til test day to ensure nothing broke.