### PR TITLE
Record data when wireless remote button D is pressed

### DIFF
--- a/sedani/sedani_chassis/sedani_chassis.ino
+++ b/sedani/sedani_chassis/sedani_chassis.ino
@@ -63,6 +63,7 @@ int songInformation3[2] = {NOTE_C5, NOTE_C5};
 
 // Manual Variables (true means human drives)
 bool isManual = true;
+double recordBag = 0.0; //0 is not recording
 
 // Servo objects
 Servo esc;
@@ -119,6 +120,7 @@ void loop()
   bool wirelessStateC = digitalRead(wirelessPinC);
   bool wirelessStateD = digitalRead(wirelessPinD);
   isManual = digitalRead(isManualPin);
+  recordBag = wirelessStateD ? 1 : 0;
   buttonEstopActive = !digitalRead(buttonEstopPin);
 
   wirelessEstopActive = !(wirelessStateB || wirelessStateC || wirelessStateD);
@@ -189,7 +191,7 @@ void loop()
   }
 
   if(gotMessage) {
-    double values[] = {currentState, currentSpeed, currentSteeringAngle};
+    double values[] = {currentState, currentSpeed, currentSteeringAngle, recordBag};
     sendFeedback(values, sizeof(values)/sizeof(double));
   }
 


### PR DESCRIPTION
Updates Sedani firmware to make button "D" (bottom right) record bag file data AND un-estop (if estopped). Pressing any other button (like estopping) will stop recording.

Once Sedani has more leds or we have a new remote, we can display to the user that we are recording and make the logic for recording smarter.
